### PR TITLE
Update quickstart.helm.sh

### DIFF
--- a/example/helm/quickstart.helm.sh
+++ b/example/helm/quickstart.helm.sh
@@ -120,7 +120,7 @@ helm upgrade --install argo-workflows argo-workflows \
 kubectl apply -f "https://raw.githubusercontent.com/kromanow94/kubeflow-manifests/${TARGET_REVISION}/example/helm/namespace.knative-serving.yaml"
 kubectl apply -f "https://raw.githubusercontent.com/kromanow94/kubeflow-manifests/${TARGET_REVISION}/example/helm/namespace.knative-eventing.yaml"
 helm upgrade --install knative-operator "${KNATIVE_OPERATOR_HELM_CHART_ARCHIVE_URL}" \
-    --namespace: knative \
+    --namespace knative \
     --wait
 
 # KServe CRDs #


### PR DESCRIPTION
Little mistake on knative-operator helm installation

**Which issue is resolved by this Pull Request:**
Resolves #

**Description of your changes:**


**Checklist:**
- [ ] Unit tests pass:
  **Make sure you have installed kustomize == 5.2.1+**
    1. `make generate-changed-only`
    2. `make test`
