### PR TITLE
fix(charts): fix some bugs in kubeflow & kubeflow-crds charts

### DIFF
--- a/charts/kubeflow-crds/templates/pipeline/scheduled-workflow-crd.yaml
+++ b/charts/kubeflow-crds/templates/pipeline/scheduled-workflow-crd.yaml
@@ -15,8 +15,6 @@ spec:
     shortNames:
     - swf
     singular: {{ include "kubeflowCrds.pipelines.scheduledWorkflow.singularName" . }}
-    shortNames:
-    - swf
   scope: Namespaced
   versions:
   - name: v1beta1

--- a/charts/kubeflow/templates/networkpolicies/ml-pipeline-ui.yaml
+++ b/charts/kubeflow/templates/networkpolicies/ml-pipeline-ui.yaml
@@ -17,7 +17,6 @@ spec:
       - key: app.kubernetes.io/subcomponent
         operator: In
         values:
-        values:
           - {{ include "kubeflow.pipelines.ui.name" . }}
   ingress:
     - from:


### PR DESCRIPTION
# Pull Request Template for Kubeflow manifests Issues

Hey @kromanow94, many thanks for maintaining an awesome helm chart for kubeflow!

While trying to upgrade kubeflow using the charts, I was met with a couple of errors originating from the chart yaml files:
- `line 24: mapping key "values" already defined at line 23` in charts/kubeflow/templates/networkpolicies/ml-pipeline-ui.yaml
- `line 23: mapping key "shortNames" already defined at line 20` in charts/kubeflow-crds/templates/pipeline/scheduled-workflow-crd.yaml

## ✏️ A brief description of the changes
> Fixed the yaml files by removing duplicate lines.

## 📦 List any dependencies that are required for this change
> None

## 🐛 If this PR is related to an issue, please put the link to the issue here.
> None

## ✅ Contributor checklist
  - Make sure you have tested with kustomize. See [Installation Prerequisites](https://github.com/kubeflow/manifests#prerequisites)
  - All the commits have been [_signed-off_](https://github.com/kubeflow/community/tree/master/dco-signoff-hook#signing-off-commits)  (To pass the `DCO` check)

---     
 
> You can join the CNCF Slack and access our meetings at the [Kubeflow Community](https://www.kubeflow.org/docs/about/community/) website. Our channel on the CNCF Slack is here [**#kubeflow-platform**](https://app.slack.com/client/T08PSQ7BQ/C073W572LA2).
  
